### PR TITLE
Transpile files before starting gulp.watch

### DIFF
--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -5,7 +5,7 @@ var gulp = require('gulp'),
   util = require('gulp-util');
 
 // Watch for changes.
-gulp.task('watch', function () {
+gulp.task('watch', ['lintjs', 'js', 'lintsass', 'sass', 'html'], function () {
   gulp.watch([global.paths.js], ['lintjs', 'js']).on('change', logChanges);
   gulp.watch([global.paths.sass], ['lintsass', 'sass']).on('change', logChanges);
   gulp.watch([global.paths.html], ['html']).on('change', logChanges);


### PR DESCRIPTION
Fixes Issue #19 - The problem is that until you save a .scss file the first time, gulp isn't generating any css file. 
